### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# fluent-plugin-ping-message, a plugin for [Fluentd](http://fluentd.org)
+# fluent-plugin-ping-message
 
-Fluentd plugins:
+[Fluentd](http://fluentd.org) plugins:
 
 * to generate ping messages for monitoring of heatbeats
 * to check ping messages not arrived, and emits notifications


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
