### PR TITLE
Add test-unit gem dependency

### DIFF
--- a/fluent-plugin-ping-message.gemspec
+++ b/fluent-plugin-ping-message.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rake"
   gem.add_development_dependency "pry"
   gem.add_development_dependency "pry-nav"
+  gem.add_development_dependency "test-unit", ">= 3.1.0"
 end


### PR DESCRIPTION
Because Ruby 2.2 does not provide minitest with test-unit compatible
layer.