### PR TITLE
Use `router.emit` instead of `Fulent::Engine.emit`

### DIFF
--- a/lib/fluent/plugin/in_ping_message.rb
+++ b/lib/fluent/plugin/in_ping_message.rb
@@ -14,6 +14,11 @@ class Fluent::PingMessageInput < Fluent::Input
   config_param :interval, :integer, :default => 60
   config_param :data, :string, :default => `hostname`.chomp
 
+  # Define `router` method of v0.12 to support v0.10.57 or earlier
+  unless method_defined?(:router)
+    define_method("router") { Engine }
+  end
+
   def start
     super
     start_pingloop

--- a/lib/fluent/plugin/in_ping_message.rb
+++ b/lib/fluent/plugin/in_ping_message.rb
@@ -35,7 +35,7 @@ class Fluent::PingMessageInput < Fluent::Input
       sleep 0.5
       if Fluent::Engine.now - @last_checked >= @interval
         @last_checked = Fluent::Engine.now
-        Fluent::Engine.emit(@tag, Fluent::Engine.now, {'data' => @data})
+        router.emit(@tag, Fluent::Engine.now, {'data' => @data})
       end
     end
   end


### PR DESCRIPTION
Because `Fluent::Engine.emit` is deprecated since fluentd v0.14