### PR TITLE
fix router fallback

### DIFF
--- a/lib/fluent/plugin/in_ping_message.rb
+++ b/lib/fluent/plugin/in_ping_message.rb
@@ -16,7 +16,7 @@ class Fluent::PingMessageInput < Fluent::Input
 
   # Define `router` method of v0.12 to support v0.10.57 or earlier
   unless method_defined?(:router)
-    define_method("router") { Engine }
+    define_method("router") { Fluent::Engine }
   end
 
   def start

--- a/lib/fluent/plugin/out_ping_message_checker.rb
+++ b/lib/fluent/plugin/out_ping_message_checker.rb
@@ -10,7 +10,7 @@ class Fluent::PingMessageCheckerOutput < Fluent::Output
 
   # Define `router` method of v0.12 to support v0.10.57 or earlier
   unless method_defined?(:router)
-    define_method("router") { Engine }
+    define_method("router") { Fluent::Engine }
   end
 
   config_param :data_field, :string, :default => 'data'


### PR DESCRIPTION
Hi @tagomoris 

Thanks for checking issue https://github.com/tagomoris/fluent-plugin-ping-message/issues/14.
As you said, it should be compatible to `fluentd-0.10.57`. However, it does not work in my environment.

```
$ /opt/td-agent/embedded/bin/ruby /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.57/bin/fluentd -c ping.conf
2016-06-14 01:11:47 +0900 [info]: starting fluentd-0.10.57
2016-06-14 01:11:47 +0900 [info]: reading config file path="ping.conf"
2016-06-14 01:11:47 +0900 [info]: gem 'fluent-mixin-config-placeholders' version '0.3.0'
2016-06-14 01:11:47 +0900 [info]: gem 'fluent-mixin-plaintextformatter' version '0.2.6'
2016-06-14 01:11:47 +0900 [info]: gem 'fluent-plugin-mongo' version '0.7.4'
2016-06-14 01:11:47 +0900 [info]: gem 'fluent-plugin-ping-message' version '0.2.0'
2016-06-14 01:11:47 +0900 [info]: gem 'fluent-plugin-rewrite-tag-filter' version '1.4.1'
2016-06-14 01:11:47 +0900 [info]: gem 'fluent-plugin-s3' version '0.4.3'
2016-06-14 01:11:47 +0900 [info]: gem 'fluent-plugin-scribe' version '0.10.13'
2016-06-14 01:11:47 +0900 [info]: gem 'fluent-plugin-td' version '0.10.22'
2016-06-14 01:11:47 +0900 [info]: gem 'fluent-plugin-td-monitoring' version '0.1.4'
2016-06-14 01:11:47 +0900 [info]: gem 'fluent-plugin-webhdfs' version '0.4.1'
2016-06-14 01:11:47 +0900 [info]: gem 'fluentd' version '0.10.57'
2016-06-14 01:11:47 +0900 [info]: using configuration file: <ROOT>
  <source>
    type ping_message
    tag ping
    interval 1
    data TEST
  </source>
  <match ping>
    type stdout
  </match>
</ROOT>
2016-06-14 01:11:47 +0900 [info]: adding source type="ping_message"
2016-06-14 01:11:47 +0900 [info]: adding match pattern="ping" type="stdout"
^C2016-06-14 01:12:01 +0900 [info]: shutting down fluentd
2016-06-14 01:12:01 +0900 [warn]: unexpected error while shutting down plugin=Fluent::PingMessageInput plugin_id="object:1742088" error_class=NameError error=#<NameError: uninitialized constant Fluent::PingMessageInput::Engine>
  2016-06-14 01:12:01 +0900 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-ping-message-0.2.0/lib/fluent/plugin/in_ping_message.rb:19:in `block in <class:PingMessageInput>'
  2016-06-14 01:12:01 +0900 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-ping-message-0.2.0/lib/fluent/plugin/in_ping_message.rb:43:in `block in pingloop'
  2016-06-14 01:12:01 +0900 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-ping-message-0.2.0/lib/fluent/plugin/in_ping_message.rb:39:in `loop'
  2016-06-14 01:12:01 +0900 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-ping-message-0.2.0/lib/fluent/plugin/in_ping_message.rb:39:in `pingloop'
2016-06-14 01:12:01 +0900 [info]: process finished code=0
```

The problem might be resolved by this PR. Please check it. 
Here is the test result after fixing.
```
$ /opt/td-agent/embedded/bin/ruby /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.57/bin/fluentd -c ping.conf
2016-06-14 01:17:05 +0900 [info]: starting fluentd-0.10.57
2016-06-14 01:17:05 +0900 [info]: reading config file path="ping.conf"
2016-06-14 01:17:05 +0900 [info]: gem 'fluent-mixin-config-placeholders' version '0.3.0'
2016-06-14 01:17:05 +0900 [info]: gem 'fluent-mixin-plaintextformatter' version '0.2.6'
2016-06-14 01:17:05 +0900 [info]: gem 'fluent-plugin-mongo' version '0.7.4'
2016-06-14 01:17:05 +0900 [info]: gem 'fluent-plugin-ping-message' version '0.2.0'
2016-06-14 01:17:05 +0900 [info]: gem 'fluent-plugin-rewrite-tag-filter' version '1.4.1'
2016-06-14 01:17:05 +0900 [info]: gem 'fluent-plugin-s3' version '0.4.3'
2016-06-14 01:17:05 +0900 [info]: gem 'fluent-plugin-scribe' version '0.10.13'
2016-06-14 01:17:05 +0900 [info]: gem 'fluent-plugin-td' version '0.10.22'
2016-06-14 01:17:05 +0900 [info]: gem 'fluent-plugin-td-monitoring' version '0.1.4'
2016-06-14 01:17:05 +0900 [info]: gem 'fluent-plugin-webhdfs' version '0.4.1'
2016-06-14 01:17:05 +0900 [info]: gem 'fluentd' version '0.10.57'
2016-06-14 01:17:05 +0900 [info]: using configuration file: <ROOT>
  <source>
    type ping_message
    tag ping
    interval 1
    data TEST
  </source>
  <match ping>
    type stdout
  </match>
</ROOT>
2016-06-14 01:17:05 +0900 [info]: adding source type="ping_message"
2016-06-14 01:17:05 +0900 [info]: adding match pattern="ping" type="stdout"
2016-06-14 01:17:06 +0900 ping: {"data":"TEST"}
2016-06-14 01:17:07 +0900 ping: {"data":"TEST"}
2016-06-14 01:17:08 +0900 ping: {"data":"TEST"}
^C2016-06-14 01:17:08 +0900 [info]: shutting down fluentd
2016-06-14 01:17:08 +0900 [info]: process finished code=0
```