### PR TITLE
in_ping_message: Fix uninitialized constant Fluent::Input error

### DIFF
--- a/lib/fluent/plugin/in_ping_message.rb
+++ b/lib/fluent/plugin/in_ping_message.rb
@@ -1,3 +1,4 @@
+require 'fluent/input'
 require 'fluent/mixin/config_placeholders'
 
 class Fluent::PingMessageInput < Fluent::Input


### PR DESCRIPTION
This change also affects Fluentd v0.12.

Without this change, the following error occurred:

```log
/Users/hhatake/Github/fluent-plugin-ping-message/lib/fluent/plugin/in_ping_message.rb:3:in `<top (required)>': uninitialized constant Fluent::Input (NameError)
	from /Users/hhatake/Github/fluent-plugin-ping-message/test/helper.rb:25:in `require'
	from /Users/hhatake/Github/fluent-plugin-ping-message/test/helper.rb:25:in `<top (required)>'
	from /Users/hhatake/Github/fluent-plugin-ping-message/test/plugin/test_out_ping_message_checker.rb:1:in `require'
	from /Users/hhatake/Github/fluent-plugin-ping-message/test/plugin/test_out_ping_message_checker.rb:1:in `<top (required)>'
	from /Users/hhatake/Github/fluent-plugin-ping-message/vendor/bundle/ruby/2.3.0/gems/rake-11.3.0/lib/rake/rake_test_loader.rb:10:in `require'
	from /Users/hhatake/Github/fluent-plugin-ping-message/vendor/bundle/ruby/2.3.0/gems/rake-11.3.0/lib/rake/rake_test_loader.rb:10:in `block (2 levels) in <main>'
	from /Users/hhatake/Github/fluent-plugin-ping-message/vendor/bundle/ruby/2.3.0/gems/rake-11.3.0/lib/rake/rake_test_loader.rb:9:in `each'
	from /Users/hhatake/Github/fluent-plugin-ping-message/vendor/bundle/ruby/2.3.0/gems/rake-11.3.0/lib/rake/rake_test_loader.rb:9:in `block in <main>'
	from /Users/hhatake/Github/fluent-plugin-ping-message/vendor/bundle/ruby/2.3.0/gems/rake-11.3.0/lib/rake/rake_test_loader.rb:4:in `select'
	from /Users/hhatake/Github/fluent-plugin-ping-message/vendor/bundle/ruby/2.3.0/gems/rake-11.3.0/lib/rake/rake_test_loader.rb:4:in `<main>'
```